### PR TITLE
Fix rare case of `ISO-8859-8-I` charset

### DIFF
--- a/lib/retriever.js
+++ b/lib/retriever.js
@@ -60,6 +60,10 @@ function retrieveSrt(path, cb, options)
                if (options && options.charset && options.charset != "auto") charset = options.charset;
                else charset = charsetDetector(buf)[0].charsetName;
 
+               // handles a special case where ISO-8859-8 IANA is detected
+               // which iconv-lite does not support directly:
+               charset = charset == 'ISO-8859-8-I' ? 'ISO-8859-8' : charset
+
                buf = iconv.decode(buf, charset) 
         } catch(e) { callback(e); return };
 


### PR DESCRIPTION
Handles a special case where `ISO-8859-8-I` (IANA encoding) is detected which `iconv-lite` does not support directly. (it does support `ISO-8859-8`)